### PR TITLE
3 :: Convert install.sql to migrations

### DIFF
--- a/database/migrations/2025_06_22_110000_create_player_table.php
+++ b/database/migrations/2025_06_22_110000_create_player_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('player', function (Blueprint $table) {
+            $table->increments('player_id');
+            $table->string('username', 20)->default('');
+            $table->string('first_name', 20)->nullable();
+            $table->string('last_name', 20)->nullable();
+            $table->string('email', 100)->default('');
+            $table->string('timezone', 255)->default('UTC');
+            $table->unsignedTinyInteger('is_admin')->default(0);
+            $table->string('password', 32)->default('');
+            $table->string('alt_pass', 32)->default('');
+            $table->string('ident', 32)->nullable();
+            $table->string('token', 32)->nullable();
+            $table->timestamp('create_date')->useCurrent();
+            $table->unsignedTinyInteger('is_approved')->default(0);
+            $table->unique('username');
+            $table->unique('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('player');
+    }
+};

--- a/database/migrations/2025_06_22_110001_create_wr_chat_table.php
+++ b/database/migrations/2025_06_22_110001_create_wr_chat_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_chat', function (Blueprint $table) {
+            $table->increments('chat_id');
+            $table->text('message');
+            $table->unsignedInteger('from_id')->default(0);
+            $table->unsignedInteger('game_id')->default(0);
+            $table->unsignedTinyInteger('private')->default(0);
+            $table->timestamp('create_date')->useCurrent();
+            $table->index('game_id');
+            $table->index('private');
+            $table->index('from_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_chat');
+    }
+};

--- a/database/migrations/2025_06_22_110002_create_wr_game_table.php
+++ b/database/migrations/2025_06_22_110002_create_wr_game_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_game', function (Blueprint $table) {
+            $table->increments('game_id');
+            $table->unsignedInteger('host_id')->default(0);
+            $table->string('name');
+            $table->string('password', 32)->nullable();
+            $table->unsignedTinyInteger('capacity')->default(2);
+            $table->unsignedTinyInteger('time_limit')->nullable();
+            $table->boolean('allow_kibitz')->default(false);
+            $table->string('game_type')->default('Original');
+            $table->unsignedTinyInteger('next_bonus')->default(4);
+            $table->enum('state', ['Waiting', 'Placing', 'Playing', 'Finished'])->default('Waiting');
+            $table->text('extra_info')->nullable();
+            $table->text('game_settings')->nullable();
+            $table->boolean('paused')->default(false);
+            $table->dateTime('create_date')->default('0000-00-00 00:00:00');
+            $table->timestamp('modify_date')->useCurrentOnUpdate()->default('0000-00-00 00:00:00');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_game');
+    }
+};

--- a/database/migrations/2025_06_22_110003_create_wr_game_land_table.php
+++ b/database/migrations/2025_06_22_110003_create_wr_game_land_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_game_land', function (Blueprint $table) {
+            $table->unsignedInteger('game_id')->default(0);
+            $table->unsignedInteger('land_id')->default(0);
+            $table->unsignedInteger('player_id')->default(0);
+            $table->unsignedSmallInteger('armies')->default(0);
+            $table->unique(['game_id', 'land_id'], 'game_land');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_game_land');
+    }
+};

--- a/database/migrations/2025_06_22_110004_create_wr_game_log_table.php
+++ b/database/migrations/2025_06_22_110004_create_wr_game_log_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_game_log', function (Blueprint $table) {
+            $table->unsignedInteger('game_id')->default(0);
+            $table->string('data')->nullable();
+            $table->dateTime('create_date', 6)->default('0000-00-00 00:00:00.000000');
+            $table->decimal('microsecond', 18, 8)->default(0);
+            $table->unique(['game_id', 'create_date', 'microsecond'], 'game_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_game_log');
+    }
+};

--- a/database/migrations/2025_06_22_110005_create_wr_game_nudge_table.php
+++ b/database/migrations/2025_06_22_110005_create_wr_game_nudge_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_game_nudge', function (Blueprint $table) {
+            $table->unsignedInteger('game_id')->default(0);
+            $table->unsignedInteger('player_id')->default(0);
+            $table->timestamp('nudged')->useCurrent();
+            $table->unique(['game_id', 'player_id'], 'game_player');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_game_nudge');
+    }
+};

--- a/database/migrations/2025_06_22_110006_create_wr_game_player_table.php
+++ b/database/migrations/2025_06_22_110006_create_wr_game_player_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_game_player', function (Blueprint $table) {
+            $table->unsignedInteger('game_id')->default(0);
+            $table->unsignedInteger('player_id')->default(0);
+            $table->unsignedTinyInteger('order_num')->default(0);
+            $table->string('color', 10)->default('');
+            $table->string('cards')->nullable();
+            $table->unsignedSmallInteger('armies')->default(0);
+            $table->enum('state', ['Waiting','Trading','Placing','Attacking','Occupying','Fortifying','Resigned','Dead'])->default('Waiting');
+            $table->unsignedTinyInteger('get_card')->default(0);
+            $table->unsignedTinyInteger('forced')->default(0);
+            $table->text('extra_info')->nullable();
+            $table->timestamp('move_date')->default('0000-00-00 00:00:00')->useCurrentOnUpdate();
+            $table->unique(['game_id', 'player_id'], 'game_player');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_game_player');
+    }
+};

--- a/database/migrations/2025_06_22_110007_create_wr_message_table.php
+++ b/database/migrations/2025_06_22_110007_create_wr_message_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_message', function (Blueprint $table) {
+            $table->increments('message_id');
+            $table->string('subject');
+            $table->text('message');
+            $table->timestamp('create_date')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_message');
+    }
+};

--- a/database/migrations/2025_06_22_110008_create_wr_message_glue_table.php
+++ b/database/migrations/2025_06_22_110008_create_wr_message_glue_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_message_glue', function (Blueprint $table) {
+            $table->increments('message_glue_id');
+            $table->unsignedInteger('message_id')->default(0);
+            $table->unsignedInteger('from_id')->default(0);
+            $table->unsignedInteger('to_id')->default(0);
+            $table->dateTime('send_date')->nullable();
+            $table->dateTime('expire_date')->nullable();
+            $table->dateTime('view_date')->nullable();
+            $table->timestamp('create_date')->useCurrent();
+            $table->unsignedTinyInteger('deleted')->default(0);
+            $table->index(['from_id', 'message_id'], 'outbox');
+            $table->index('create_date', 'created');
+            $table->index('expire_date');
+            $table->index(['to_id', 'from_id', 'send_date', 'deleted'], 'inbox');
+            $table->index(['message_id', 'to_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_message_glue');
+    }
+};

--- a/database/migrations/2025_06_22_110009_create_wr_roll_log_table.php
+++ b/database/migrations/2025_06_22_110009_create_wr_roll_log_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_roll_log', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedTinyInteger('attack_1')->default(0);
+            $table->unsignedTinyInteger('attack_2')->nullable();
+            $table->unsignedTinyInteger('attack_3')->nullable();
+            $table->unsignedTinyInteger('defend_1')->default(0);
+            $table->unsignedTinyInteger('defend_2')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_roll_log');
+    }
+};

--- a/database/migrations/2025_06_22_110010_create_wr_settings_table.php
+++ b/database/migrations/2025_06_22_110010_create_wr_settings_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_settings', function (Blueprint $table) {
+            $table->string('setting')->default('');
+            $table->text('value');
+            $table->text('notes')->nullable();
+            $table->unsignedSmallInteger('sort')->default(0);
+            $table->unique('setting');
+            $table->index('sort');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_settings');
+    }
+};

--- a/database/migrations/2025_06_22_110011_create_wr_wr_player_table.php
+++ b/database/migrations/2025_06_22_110011_create_wr_wr_player_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wr_wr_player', function (Blueprint $table) {
+            $table->unsignedInteger('player_id')->default(0);
+            $table->text('game_settings')->nullable();
+            $table->unsignedTinyInteger('is_admin')->default(0);
+            $table->unsignedTinyInteger('allow_email')->default(1);
+            $table->string('color', 25)->default('yellow_black');
+            $table->boolean('invite_opt_out')->default(false);
+            $table->unsignedTinyInteger('max_games')->default(0);
+            $table->unsignedSmallInteger('wins')->default(0);
+            $table->unsignedSmallInteger('kills')->default(0);
+            $table->unsignedSmallInteger('losses')->default(0);
+            $table->timestamp('last_online')->default('0000-00-00 00:00:00')->useCurrentOnUpdate();
+            $table->unique('player_id', 'id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wr_wr_player');
+    }
+};


### PR DESCRIPTION
## Summary
- add Laravel migrations for each legacy table

## Testing
- `php artisan migrate --pretend` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857de448c5c8333b5543b33ab4ad53f