### PR TITLE
6 :: Add PHPUnit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ A fresh Laravel application now lives in the project root.
    ```
 
 This will set up an empty game database ready for development.
+
+## Running Tests
+
+Execute the full PHPUnit test suite using Artisan:
+
+```
+php artisan test
+```
+
+This command runs the unit and feature tests using an in-memory SQLite database.

--- a/database/factories/WrGameFactory.php
+++ b/database/factories/WrGameFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\WrGame;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class WrGameFactory extends Factory
+{
+    protected $model = WrGame::class;
+
+    public function definition(): array
+    {
+        return [
+            'host_id' => 1,
+            'name' => fake()->sentence(2),
+            'capacity' => 2,
+            'allow_kibitz' => false,
+            'game_type' => 'Original',
+            'next_bonus' => 4,
+            'state' => 'Waiting',
+            'paused' => false,
+        ];
+    }
+}

--- a/tests/Feature/GameRoutesTest.php
+++ b/tests/Feature/GameRoutesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Player;
+use App\Models\WrGame;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GameRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_games_index_returns_successful_response(): void
+    {
+        $host = Player::factory()->create();
+        WrGame::factory()->create(['host_id' => $host->player_id, 'name' => 'Test Game']);
+        $response = $this->get('/games');
+        $response->assertStatus(200);
+    }
+
+    public function test_game_show_returns_successful_response(): void
+    {
+        $host = Player::factory()->create();
+        $game = WrGame::factory()->create(['host_id' => $host->player_id, 'name' => 'Show Game']);
+        $response = $this->get('/games/'.$game->game_id);
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RegisterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_registration_form_displays(): void
+    {
+        $response = $this->get('/register');
+        $response->assertStatus(200);
+    }
+
+    public function test_user_can_register(): void
+    {
+        $response = $this->post('/register', [
+            'username' => 'tester',
+            'email' => 'tester@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertRedirect('/games');
+        $this->assertDatabaseHas('player', ['username' => 'tester']);
+    }
+}

--- a/tests/Unit/PlayerHashingTest.php
+++ b/tests/Unit/PlayerHashingTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Player;
+use Tests\TestCase;
+
+class PlayerHashingTest extends TestCase
+{
+    public function test_hash_password(): void
+    {
+        $expected = md5('secret'.'NUTTY!SALT');
+        $this->assertSame($expected, Player::hashPassword('secret'));
+    }
+
+    public function test_hash_alt_pass(): void
+    {
+        $password = 'secret';
+        $expected = md5(str_rot13($password).substr(md5(md5(strrev($password)).md5($password)), 10, 32).'SALTY!NUTS');
+        $this->assertSame($expected, Player::hashAltPass($password));
+    }
+}


### PR DESCRIPTION
## Summary
- create RegisterTest and GameRoutesTest feature tests
- add PlayerHashingTest unit test and factory for `WrGame`
- document how to run the test suite

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68580b50e8188333900a9ad0ee8c819c