### PR TITLE
FEATURE :: Add profile update

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Player;
+
+class ProfileController extends Controller
+{
+    public function edit(Request $request)
+    {
+        $player = Player::findOrFail($request->session()->get('player_id'));
+        $timezones = timezone_identifiers_list();
+        return view('profile.edit', compact('player', 'timezones'));
+    }
+
+    public function update(Request $request)
+    {
+        $player = Player::findOrFail($request->session()->get('player_id'));
+
+        $data = $request->validate([
+            'first_name' => 'nullable|string|max:20',
+            'last_name' => 'nullable|string|max:20',
+            'email' => 'required|email|unique:player,email,'.$player->player_id.',player_id',
+            'timezone' => 'nullable|string',
+            'password' => 'nullable|confirmed',
+            'current_password' => 'required_with:password',
+        ]);
+
+        if ($data['password'] ?? false) {
+            if ($player->password !== Player::hashPassword($data['current_password'])) {
+                return back()->withErrors(['current_password' => 'Invalid password'])->withInput();
+            }
+            $player->password = Player::hashPassword($data['password']);
+            $player->alt_pass = Player::hashAltPass($data['password']);
+        }
+
+        $player->first_name = $data['first_name'];
+        $player->last_name = $data['last_name'];
+        $player->email = $data['email'];
+        $player->timezone = $data['timezone'] ?: 'UTC';
+        $player->save();
+
+        return redirect('/profile')->with('status', 'Profile updated');
+    }
+}

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,0 +1,49 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Edit Profile</h1>
+@if(session('status'))
+    <div>{{ session('status') }}</div>
+@endif
+<form method="post" action="/profile">
+    @csrf
+    <div>
+        <label>Username</label>
+        <span>{{ $player->username }}</span>
+    </div>
+    <div>
+        <label>First Name</label>
+        <input type="text" name="first_name" value="{{ old('first_name', $player->first_name) }}">
+    </div>
+    <div>
+        <label>Last Name</label>
+        <input type="text" name="last_name" value="{{ old('last_name', $player->last_name) }}">
+    </div>
+    <div>
+        <label>Email</label>
+        <input type="email" name="email" value="{{ old('email', $player->email) }}">
+    </div>
+    <div>
+        <label>Timezone</label>
+        <select name="timezone">
+            <option value="">Use Game Default (UTC)</option>
+            @foreach($timezones as $zone)
+                <option value="{{ $zone }}" @selected(old('timezone', $player->timezone) === $zone)>{{ $zone }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div>
+        <label>Current Password</label>
+        <input type="password" name="current_password">
+    </div>
+    <div>
+        <label>New Password</label>
+        <input type="password" name="password">
+    </div>
+    <div>
+        <label>Confirm Password</label>
+        <input type="password" name="password_confirmation">
+    </div>
+    <button type="submit">Update Profile</button>
+</form>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\RegisterController;
 use App\Http\Controllers\GameController;
+use App\Http\Controllers\ProfileController;
 
 Route::get('/', [GameController::class, 'index']);
 
@@ -20,3 +21,8 @@ Route::controller(RegisterController::class)->group(function () {
 
 Route::get('/games', [GameController::class, 'index']);
 Route::get('/games/{game}', [GameController::class, 'show']);
+
+Route::controller(ProfileController::class)->group(function () {
+    Route::get('/profile', 'edit');
+    Route::post('/profile', 'update');
+});

--- a/tests/Feature/ProfileUpdateTest.php
+++ b/tests/Feature/ProfileUpdateTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Player;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProfileUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_profile_form_displays(): void
+    {
+        $player = Player::factory()->create();
+        $response = $this->withSession(['player_id' => $player->player_id])->get('/profile');
+        $response->assertStatus(200);
+    }
+
+    public function test_user_can_update_profile(): void
+    {
+        $player = Player::factory()->create([
+            'password' => Player::hashPassword('oldpass'),
+            'alt_pass' => Player::hashAltPass('oldpass'),
+        ]);
+
+        $response = $this->withSession(['player_id' => $player->player_id])->post('/profile', [
+            'first_name' => 'New',
+            'last_name' => 'Name',
+            'email' => 'new@example.com',
+            'timezone' => 'UTC',
+            'current_password' => 'oldpass',
+            'password' => 'newpass',
+            'password_confirmation' => 'newpass',
+        ]);
+
+        $response->assertRedirect('/profile');
+        $this->assertDatabaseHas('player', [
+            'player_id' => $player->player_id,
+            'first_name' => 'New',
+            'email' => 'new@example.com',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add ProfileController with edit & update actions
- create profile routes
- build edit profile blade view
- test profile update

## Testing
- `vendor/bin/phpunit --stop-on-error --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68584a5e719483339768b4e4c08c7ee6