### PR TITLE
FEATURE :: add game creation workflow

### DIFF
--- a/app/Http/Controllers/GameController.php
+++ b/app/Http/Controllers/GameController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Game;
+use App\Models\GamePlayer;
 use Illuminate\Http\Request;
 
 class GameController extends Controller
@@ -16,5 +17,100 @@ class GameController extends Controller
     public function show(Game $game)
     {
         return view('games.show', compact('game'));
+    }
+
+    public function create()
+    {
+        return view('games.create');
+    }
+
+    public function store(Request $request)
+    {
+        $playerId = $request->session()->get('player_id');
+        $data = $request->validate([
+            'name' => 'required|max:255',
+            'capacity' => 'required|integer|between:2,6',
+            'password' => 'nullable|string',
+            'allow_kibitz' => 'boolean',
+            'fortify' => 'required|boolean',
+            'multiple_fortify' => 'boolean',
+            'connected_fortify' => 'boolean',
+            'kamikaze' => 'boolean',
+            'warmonger' => 'boolean',
+            'fog_of_war_armies' => 'required|in:all,adjacent,none',
+            'fog_of_war_colors' => 'required|in:all,adjacent,none',
+            'nuke' => 'boolean',
+            'turncoat' => 'boolean',
+            'place_initial_armies' => 'boolean',
+            'initial_army_limit' => 'required|integer|min:0',
+        ]);
+
+        $extra = [
+            'fortify' => (bool) $data['fortify'],
+            'multiple_fortify' => (bool) ($data['multiple_fortify'] ?? false),
+            'connected_fortify' => (bool) ($data['connected_fortify'] ?? false),
+            'kamikaze' => (bool) ($data['kamikaze'] ?? false),
+            'warmonger' => (bool) ($data['warmonger'] ?? false),
+            'fog_of_war_armies' => $data['fog_of_war_armies'],
+            'fog_of_war_colors' => $data['fog_of_war_colors'],
+            'nuke' => (bool) ($data['nuke'] ?? false),
+            'turncoat' => (bool) ($data['turncoat'] ?? false),
+            'place_initial_armies' => (bool) ($data['place_initial_armies'] ?? false),
+            'initial_army_limit' => (int) $data['initial_army_limit'],
+        ];
+
+        $game = Game::create([
+            'host_id' => $playerId,
+            'name' => $data['name'],
+            'password' => isset($data['password']) && $data['password'] !== '' ? Game::hashPassword($data['password']) : null,
+            'capacity' => $data['capacity'],
+            'allow_kibitz' => $data['allow_kibitz'] ?? false,
+            'extra_info' => json_encode($extra),
+        ]);
+
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $playerId,
+            'order_num' => 1,
+            'color' => 'red',
+            'state' => 'Waiting',
+        ]);
+
+        return redirect('/games/' . $game->game_id);
+    }
+
+    public function join(Request $request, Game $game)
+    {
+        if ($request->isMethod('post')) {
+            $playerId = $request->session()->get('player_id');
+            $data = $request->validate([
+                'color' => 'required|in:red,blue,green,yellow,brown,black',
+                'password' => 'nullable|string',
+            ]);
+
+            if ($game->password && Game::hashPassword($data['password'] ?? '') !== $game->password) {
+                return back()->withErrors(['password' => 'Invalid password'])->withInput();
+            }
+
+            if ($game->players()->count() >= $game->capacity) {
+                return back()->withErrors(['color' => 'Game full']);
+            }
+
+            if ($game->players()->where('color', $data['color'])->exists()) {
+                return back()->withErrors(['color' => 'Color taken']);
+            }
+
+            GamePlayer::create([
+                'game_id' => $game->game_id,
+                'player_id' => $playerId,
+                'order_num' => $game->players()->count() + 1,
+                'color' => $data['color'],
+                'state' => 'Waiting',
+            ]);
+
+            return redirect('/games/' . $game->game_id);
+        }
+
+        return view('games.join', compact('game'));
     }
 }

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -49,4 +49,9 @@ class Game extends Model
     {
         return $this->hasMany(Chat::class, 'game_id');
     }
+
+    public static function hashPassword(string $password): string
+    {
+        return md5($password.'s41Ty!S7uFF');
+    }
 }

--- a/database/factories/GamePlayerFactory.php
+++ b/database/factories/GamePlayerFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\GamePlayer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class GamePlayerFactory extends Factory
+{
+    protected $model = GamePlayer::class;
+
+    public function definition(): array
+    {
+        return [
+            'game_id' => 1,
+            'player_id' => 1,
+            'order_num' => 1,
+            'color' => 'red',
+            'state' => 'Waiting',
+        ];
+    }
+}

--- a/resources/views/games/create.blade.php
+++ b/resources/views/games/create.blade.php
@@ -1,0 +1,67 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Create Game</h1>
+<form method="post" action="/games">
+    @csrf
+    <div>
+        <label>Game Name</label>
+        <input type="text" name="name" value="{{ old('name') }}">
+    </div>
+    <div>
+        <label>Capacity</label>
+        <select name="capacity">
+            @for($i = 2; $i <= 6; $i++)
+                <option value="{{ $i }}" @selected(old('capacity',6)==$i)>{{ $i }}</option>
+            @endfor
+        </select>
+    </div>
+    <div>
+        <label>Allow Kibitz</label>
+        <input type="checkbox" name="allow_kibitz" value="1" @checked(old('allow_kibitz'))>
+    </div>
+    <div>
+        <label>Fortify</label>
+        <label><input type="radio" name="fortify" value="1" @checked(old('fortify',1))>Yes</label>
+        <label><input type="radio" name="fortify" value="0" @checked(old('fortify')==='0')>No</label>
+        <label><input type="checkbox" name="multiple_fortify" value="1" @checked(old('multiple_fortify'))>Multiple</label>
+        <label><input type="checkbox" name="connected_fortify" value="1" @checked(old('connected_fortify'))>Connected</label>
+    </div>
+    <div>
+        <label><input type="checkbox" name="kamikaze" value="1" @checked(old('kamikaze'))>Kamikaze</label>
+    </div>
+    <div>
+        <label><input type="checkbox" name="warmonger" value="1" @checked(old('warmonger'))>Warmonger</label>
+    </div>
+    <div>
+        <label>Fog of War Armies</label>
+        <label><input type="radio" name="fog_of_war_armies" value="all" @checked(old('fog_of_war_armies','all')=='all')>All</label>
+        <label><input type="radio" name="fog_of_war_armies" value="adjacent" @checked(old('fog_of_war_armies')=='adjacent')>Adjacent</label>
+        <label><input type="radio" name="fog_of_war_armies" value="none" @checked(old('fog_of_war_armies')=='none')>None</label>
+    </div>
+    <div>
+        <label>Fog of War Colors</label>
+        <label><input type="radio" name="fog_of_war_colors" value="all" @checked(old('fog_of_war_colors','all')=='all')>All</label>
+        <label><input type="radio" name="fog_of_war_colors" value="adjacent" @checked(old('fog_of_war_colors')=='adjacent')>Adjacent</label>
+        <label><input type="radio" name="fog_of_war_colors" value="none" @checked(old('fog_of_war_colors')=='none')>None</label>
+    </div>
+    <div>
+        <label><input type="checkbox" name="nuke" value="1" @checked(old('nuke'))>Nuclear War</label>
+    </div>
+    <div>
+        <label><input type="checkbox" name="turncoat" value="1" @checked(old('turncoat'))>Turncoat</label>
+    </div>
+    <div>
+        <label><input type="checkbox" name="place_initial_armies" value="1" @checked(old('place_initial_armies'))>Random Placement</label>
+    </div>
+    <div>
+        <label>Placement Limit</label>
+        <input type="number" name="initial_army_limit" value="{{ old('initial_army_limit',0) }}">
+    </div>
+    <div>
+        <label>Password</label>
+        <input type="password" name="password">
+    </div>
+    <button type="submit">Create Game</button>
+</form>
+@endsection

--- a/resources/views/games/join.blade.php
+++ b/resources/views/games/join.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Join {{ $game->name }}</h1>
+<form method="post" action="/games/{{ $game->game_id }}/join">
+    @csrf
+    <div>
+        <label>Your Color</label>
+        <select name="color">
+            @foreach(['red','blue','green','yellow','brown','black'] as $color)
+                <option value="{{ $color }}" @selected(old('color')==$color)>{{ ucfirst($color) }}</option>
+            @endforeach
+        </select>
+    </div>
+    @if($game->password)
+    <div>
+        <label>Password</label>
+        <input type="password" name="password">
+    </div>
+    @endif
+    <button type="submit">Join Game</button>
+</form>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,4 +19,7 @@ Route::controller(RegisterController::class)->group(function () {
 });
 
 Route::get('/games', [GameController::class, 'index']);
+Route::get('/games/create', [GameController::class, 'create']);
+Route::post('/games', [GameController::class, 'store']);
+Route::match(['get','post'], '/games/{game}/join', [GameController::class, 'join']);
 Route::get('/games/{game}', [GameController::class, 'show']);

--- a/tests/Feature/GameRoutesTest.php
+++ b/tests/Feature/GameRoutesTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Player;
 use App\Models\Game;
+use App\Models\GamePlayer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -25,5 +26,52 @@ class GameRoutesTest extends TestCase
         $game = Game::factory()->create(['host_id' => $host->player_id, 'name' => 'Show Game']);
         $response = $this->get('/games/'.$game->game_id);
         $response->assertStatus(200);
+    }
+
+    public function test_create_form_displays(): void
+    {
+        $response = $this->get('/games/create');
+        $response->assertStatus(200);
+    }
+
+    public function test_player_can_create_game(): void
+    {
+        $player = Player::factory()->create();
+        $this->withSession(['player_id' => $player->player_id]);
+        $response = $this->post('/games', [
+            'name' => 'New Game',
+            'capacity' => 2,
+            'fortify' => true,
+            'fog_of_war_armies' => 'all',
+            'fog_of_war_colors' => 'all',
+            'initial_army_limit' => 0,
+        ]);
+        $game = Game::first();
+        $response->assertRedirect('/games/'.$game->game_id);
+        $this->assertDatabaseHas('games', ['name' => 'New Game']);
+        $this->assertDatabaseHas('game_players', ['game_id' => $game->game_id, 'player_id' => $player->player_id]);
+    }
+
+    public function test_join_form_displays(): void
+    {
+        $host = Player::factory()->create();
+        $game = Game::factory()->create(['host_id' => $host->player_id]);
+        GamePlayer::create(['game_id' => $game->game_id, 'player_id' => $host->player_id, 'order_num' => 1, 'color' => 'red', 'state' => 'Waiting']);
+        $response = $this->get('/games/'.$game->game_id.'/join');
+        $response->assertStatus(200);
+    }
+
+    public function test_player_can_join_game(): void
+    {
+        $host = Player::factory()->create();
+        $game = Game::factory()->create(['host_id' => $host->player_id]);
+        GamePlayer::create(['game_id' => $game->game_id, 'player_id' => $host->player_id, 'order_num' => 1, 'color' => 'red', 'state' => 'Waiting']);
+        $player = Player::factory()->create();
+        $this->withSession(['player_id' => $player->player_id]);
+        $response = $this->post('/games/'.$game->game_id.'/join', [
+            'color' => 'blue',
+        ]);
+        $response->assertRedirect('/games/'.$game->game_id);
+        $this->assertDatabaseHas('game_players', ['game_id' => $game->game_id, 'player_id' => $player->player_id]);
     }
 }


### PR DESCRIPTION
## Summary
- extend `GameController` with create, store, and join actions
- add game-related routes
- store game settings via `hashPassword` helper
- create simple game creation and join views
- add factories and feature tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68584a7cfaec8333ad62168e64b8a0d7