### PR TITLE
HOTFIX :: fix datetime defaults

### DIFF
--- a/database/migrations/2025_06_22_110002_create_games_table.php
+++ b/database/migrations/2025_06_22_110002_create_games_table.php
@@ -22,8 +22,8 @@ return new class extends Migration
             $table->text('extra_info')->nullable();
             $table->text('game_settings')->nullable();
             $table->boolean('paused')->default(false);
-            $table->dateTime('create_date')->default('0000-00-00 00:00:00');
-            $table->timestamp('modify_date')->useCurrentOnUpdate()->default('0000-00-00 00:00:00');
+            $table->dateTime('create_date')->useCurrent();
+            $table->timestamp('modify_date')->useCurrent()->useCurrentOnUpdate();
         });
     }
 

--- a/database/migrations/2025_06_22_110004_create_game_logs_table.php
+++ b/database/migrations/2025_06_22_110004_create_game_logs_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('game_logs', function (Blueprint $table) {
             $table->unsignedInteger('game_id')->default(0);
             $table->string('data')->nullable();
-            $table->dateTime('create_date', 6)->default('0000-00-00 00:00:00.000000');
+            $table->dateTime('create_date', 6)->useCurrent();
             $table->decimal('microsecond', 18, 8)->default(0);
             $table->unique(['game_id', 'create_date', 'microsecond'], 'game_id');
         });

--- a/database/migrations/2025_06_22_110006_create_game_players_table.php
+++ b/database/migrations/2025_06_22_110006_create_game_players_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->unsignedTinyInteger('get_card')->default(0);
             $table->unsignedTinyInteger('forced')->default(0);
             $table->text('extra_info')->nullable();
-            $table->timestamp('move_date')->default('0000-00-00 00:00:00')->useCurrentOnUpdate();
+            $table->timestamp('move_date')->useCurrent()->useCurrentOnUpdate();
             $table->unique(['game_id', 'player_id'], 'game_player_unique');
         });
     }

--- a/database/migrations/2025_06_22_110011_create_wr_player_table.php
+++ b/database/migrations/2025_06_22_110011_create_wr_player_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->unsignedSmallInteger('wins')->default(0);
             $table->unsignedSmallInteger('kills')->default(0);
             $table->unsignedSmallInteger('losses')->default(0);
-            $table->timestamp('last_online')->default('0000-00-00 00:00:00')->useCurrentOnUpdate();
+            $table->timestamp('last_online')->useCurrent()->useCurrentOnUpdate();
             $table->unique('player_id', 'id');
         });
     }


### PR DESCRIPTION
## Summary
- allow MySQL to use current timestamps for new games and player stats

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685862956f9c83338947e611b7a9fa93