### PR TITLE
FEATURE :: Add preferences management

### DIFF
--- a/app/Http/Controllers/PreferencesController.php
+++ b/app/Http/Controllers/PreferencesController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Player;
+use App\Models\PlayerSettings;
+
+class PreferencesController extends Controller
+{
+    public function edit(Request $request)
+    {
+        $player = Player::findOrFail($request->session()->get('player_id'));
+        $prefs = $player->settings ?? PlayerSettings::create(['player_id' => $player->player_id]);
+        $colorFiles = glob(base_path('legacy/css/c_*.css'));
+        $colors = array_map(fn($path) => substr(basename($path, '.css'), 2), $colorFiles);
+        sort($colors);
+        return view('prefs.edit', compact('prefs', 'colors'));
+    }
+
+    public function update(Request $request)
+    {
+        $player = Player::findOrFail($request->session()->get('player_id'));
+        $prefs = $player->settings ?? PlayerSettings::create(['player_id' => $player->player_id]);
+
+        $data = $request->validate([
+            'allow_email' => 'nullable|boolean',
+            'invite_opt_out' => 'nullable|boolean',
+            'max_games' => 'nullable|integer|min:0',
+            'color' => 'nullable|string',
+        ]);
+
+        $prefs->allow_email = $data['allow_email'] ?? false;
+        $prefs->invite_opt_out = $data['invite_opt_out'] ?? false;
+        $prefs->max_games = $data['max_games'] ?? 0;
+        $prefs->color = $data['color'] ?? '';
+        $prefs->save();
+
+        return redirect('/prefs')->with('status', 'Preferences updated');
+    }
+}

--- a/resources/views/prefs/edit.blade.php
+++ b/resources/views/prefs/edit.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Edit Preferences</h1>
+@if(session('status'))
+    <div>{{ session('status') }}</div>
+@endif
+<form method="post" action="/prefs">
+    @csrf
+    <div>
+        <label><input type="checkbox" name="allow_email" value="1" @checked(old('allow_email', $prefs->allow_email))>Allow email</label>
+    </div>
+    <div>
+        <label><input type="checkbox" name="invite_opt_out" value="1" @checked(old('invite_opt_out', $prefs->invite_opt_out))>Opt out of invites</label>
+    </div>
+    <div>
+        <label>Max games</label>
+        <input type="number" name="max_games" value="{{ old('max_games', $prefs->max_games) }}">
+    </div>
+    <div>
+        <label>Theme color</label>
+        <select name="color">
+            <option value="">Use Default</option>
+            @foreach($colors as $color)
+                <option value="{{ $color }}" @selected(old('color', $prefs->color)===$color)>{{ ucwords(str_replace('_',' ',$color)) }}</option>
+            @endforeach
+        </select>
+    </div>
+    <button type="submit">Save Preferences</button>
+</form>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\GameController;
 use App\Http\Controllers\ChatController;
 use App\Http\Controllers\MessageController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\PreferencesController;
 
 Route::get('/', [GameController::class, 'index']);
 
@@ -44,4 +45,9 @@ Route::controller(MessageController::class)->prefix('messages')->group(function 
 Route::controller(ProfileController::class)->group(function () {
     Route::get('/profile', 'edit');
     Route::post('/profile', 'update');
+});
+
+Route::controller(PreferencesController::class)->group(function () {
+    Route::get('/prefs', 'edit');
+    Route::post('/prefs', 'update');
 });

--- a/tests/Feature/PreferencesTest.php
+++ b/tests/Feature/PreferencesTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Player;
+use App\Models\PlayerSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PreferencesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_preferences_form_displays(): void
+    {
+        $player = Player::factory()->create();
+        PlayerSettings::create(['player_id' => $player->player_id]);
+        $response = $this->withSession(['player_id' => $player->player_id])->get('/prefs');
+        $response->assertStatus(200);
+    }
+
+    public function test_player_can_update_preferences(): void
+    {
+        $player = Player::factory()->create();
+        PlayerSettings::create(['player_id' => $player->player_id]);
+
+        $response = $this->withSession(['player_id' => $player->player_id])->post('/prefs', [
+            'allow_email' => '1',
+            'invite_opt_out' => '1',
+            'max_games' => 3,
+            'color' => 'red_black',
+        ]);
+
+        $response->assertRedirect('/prefs');
+        $this->assertDatabaseHas('wr_player', [
+            'player_id' => $player->player_id,
+            'allow_email' => 1,
+            'invite_opt_out' => 1,
+            'max_games' => 3,
+            'color' => 'red_black',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add PreferencesController for user prefs
- wire `/prefs` routes
- build preferences edit view
- test updating preferences

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6858615a7a3483339e99e25c83360bbd