### PR TITLE
FEATURE :: Add game archive

### DIFF
--- a/app/Http/Controllers/ArchiveController.php
+++ b/app/Http/Controllers/ArchiveController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Game;
+
+class ArchiveController extends Controller
+{
+    public function index()
+    {
+        $games = Game::where('state', 'Finished')
+            ->orderByDesc('modify_date')
+            ->get();
+        return view('archive.index', compact('games'));
+    }
+}

--- a/resources/views/archive/index.blade.php
+++ b/resources/views/archive/index.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Archived Games</h1>
+<table>
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Start Date</th>
+            <th>End Date</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($games as $game)
+        <tr>
+            <td>{{ $game->game_id }}</td>
+            <td>{{ $game->name }}</td>
+            <td>{{ $game->create_date }}</td>
+            <td>{{ $game->modify_date }}</td>
+        </tr>
+        @empty
+        <tr>
+            <td colspan="4">There are no games to show</td>
+        </tr>
+        @endforelse
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,8 +8,11 @@ use App\Http\Controllers\ChatController;
 use App\Http\Controllers\MessageController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\PreferencesController;
+use App\Http\Controllers\ArchiveController;
 
 Route::get('/', [GameController::class, 'index']);
+
+Route::get('/archive', [ArchiveController::class, 'index']);
 
 Route::controller(AuthController::class)->group(function () {
     Route::get('/login', 'showLoginForm')->name('login');

--- a/tests/Feature/ArchiveTest.php
+++ b/tests/Feature/ArchiveTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Game;
+
+class ArchiveTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_archive_page_shows_finished_games(): void
+    {
+        Game::factory()->create(['name' => 'Finished One', 'state' => 'Finished']);
+        $response = $this->get('/archive');
+        $response->assertStatus(200);
+        $response->assertSee('Finished One');
+    }
+}


### PR DESCRIPTION
## Summary
- archive finished games
- route /archive to ArchiveController
- show archived games in a table
- test archive page shows finished games

## Testing
- `vendor/bin/phpunit tests/Feature/ArchiveTest.php`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68586937f3808333a4084d1ecc578560