### PR TITLE
FEATURE :: Add admin controls

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Player;
+use App\Models\Game;
+use App\Models\Setting;
+use Illuminate\Http\Request;
+
+class AdminController extends Controller
+{
+    public function dashboard()
+    {
+        $players = Player::where('is_approved', false)->get();
+        $games = Game::all();
+        return view('admin.dashboard', compact('players', 'games'));
+    }
+
+    public function approvePlayer(Player $player)
+    {
+        $player->update(['is_approved' => true]);
+        return redirect('/admin');
+    }
+
+    public function pauseGame(Game $game)
+    {
+        $game->update(['paused' => true]);
+        return redirect('/admin');
+    }
+
+    public function unpauseGame(Game $game)
+    {
+        $game->update(['paused' => false]);
+        return redirect('/admin');
+    }
+
+    public function settingsForm()
+    {
+        $settings = Setting::orderBy('sort')->get();
+        return view('admin.settings', compact('settings'));
+    }
+
+    public function updateSettings(Request $request)
+    {
+        $data = $request->validate(['settings' => 'array']);
+        foreach ($data['settings'] ?? [] as $key => $value) {
+            Setting::where('setting', $key)->update(['value' => $value]);
+        }
+        return redirect('/admin/settings');
+    }
+}

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Player;
+use Closure;
+
+class AdminMiddleware
+{
+    public function handle($request, Closure $next)
+    {
+        $playerId = $request->session()->get('player_id');
+        $player = $playerId ? Player::find($playerId) : null;
+        if (! $player || ! $player->is_admin) {
+            return redirect('/login');
+        }
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\AdminMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Admin Dashboard</h1>
+<h2>Pending Players</h2>
+<ul>
+@foreach($players as $player)
+    <li>
+        {{ $player->username }}
+        <form method="post" action="/admin/players/{{ $player->player_id }}/approve" style="display:inline">
+            @csrf
+            <button type="submit">Approve</button>
+        </form>
+    </li>
+@endforeach
+</ul>
+<h2>Games</h2>
+<ul>
+@foreach($games as $game)
+    <li>
+        {{ $game->name }} ({{ $game->paused ? 'Paused' : 'Active' }})
+        @if($game->paused)
+            <form method="post" action="/admin/games/{{ $game->game_id }}/unpause" style="display:inline">
+                @csrf
+                <button type="submit">Unpause</button>
+            </form>
+        @else
+            <form method="post" action="/admin/games/{{ $game->game_id }}/pause" style="display:inline">
+                @csrf
+                <button type="submit">Pause</button>
+            </form>
+        @endif
+    </li>
+@endforeach
+</ul>
+<a href="/admin/settings">Settings</a>
+@endsection

--- a/resources/views/admin/settings.blade.php
+++ b/resources/views/admin/settings.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Settings</h1>
+<form method="post" action="/admin/settings">
+    @csrf
+    <table>
+        <thead>
+            <tr><th>Setting</th><th>Value</th></tr>
+        </thead>
+        <tbody>
+        @foreach($settings as $setting)
+            <tr>
+                <td>{{ $setting->setting }}</td>
+                <td><input type="text" name="settings[{{ $setting->setting }}]" value="{{ $setting->value }}"></td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+    <button type="submit">Save</button>
+</form>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -8,6 +8,10 @@
     <nav>
         @if(session('player_id'))
             <a href="/games">Games</a> |
+            @php($player = \App\Models\Player::find(session('player_id')))
+            @if($player?->is_admin)
+                <a href="/admin">Admin</a> |
+            @endif
             <a href="/logout">Logout</a>
         @else
             <a href="/login">Login</a> |

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ChatController;
 use App\Http\Controllers\MessageController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\PreferencesController;
+use App\Http\Controllers\AdminController;
 
 Route::get('/', [GameController::class, 'index']);
 
@@ -50,4 +51,13 @@ Route::controller(ProfileController::class)->group(function () {
 Route::controller(PreferencesController::class)->group(function () {
     Route::get('/prefs', 'edit');
     Route::post('/prefs', 'update');
+});
+
+Route::middleware('admin')->prefix('admin')->controller(AdminController::class)->group(function () {
+    Route::get('/', 'dashboard');
+    Route::post('/players/{player}/approve', 'approvePlayer');
+    Route::post('/games/{game}/pause', 'pauseGame');
+    Route::post('/games/{game}/unpause', 'unpauseGame');
+    Route::get('/settings', 'settingsForm');
+    Route::post('/settings', 'updateSettings');
 });

--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Player;
+use App\Models\Game;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_approve_player(): void
+    {
+        $admin = Player::factory()->create(['is_admin' => true]);
+        $player = Player::factory()->create(['is_approved' => false]);
+
+        $response = $this->withSession(['player_id' => $admin->player_id])
+            ->post('/admin/players/'.$player->player_id.'/approve');
+
+        $response->assertRedirect('/admin');
+        $this->assertTrue($player->fresh()->is_approved);
+    }
+
+    public function test_admin_can_pause_and_unpause_game(): void
+    {
+        $admin = Player::factory()->create(['is_admin' => true]);
+        $game = Game::factory()->create();
+
+        $this->withSession(['player_id' => $admin->player_id])
+            ->post('/admin/games/'.$game->game_id.'/pause')
+            ->assertRedirect('/admin');
+
+        $this->assertTrue($game->fresh()->paused);
+
+        $this->withSession(['player_id' => $admin->player_id])
+            ->post('/admin/games/'.$game->game_id.'/unpause')
+            ->assertRedirect('/admin');
+
+        $this->assertFalse($game->fresh()->paused);
+    }
+}


### PR DESCRIPTION
## Summary
- add admin dashboard and settings views
- implement `AdminController` with moderation and game pause features
- require admins via new `AdminMiddleware`
- expose admin routes and update layout navigation
- test admin approving players and pausing games

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6858693b9a48833383602f0621028204