### PR TITLE
FEATURE :: Add nudge functionality

### DIFF
--- a/resources/views/games/show.blade.php
+++ b/resources/views/games/show.blade.php
@@ -3,4 +3,10 @@
 @section('content')
 <h1>{{ $game->name }}</h1>
 <p>State: {{ $game->state }}</p>
+@if(isset($canNudge) && $canNudge)
+<form method="post" action="/games/{{ $game->game_id }}/nudge">
+    @csrf
+    <button type="submit">Nudge</button>
+</form>
+@endif
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,7 @@ Route::get('/games/create', [GameController::class, 'create']);
 Route::post('/games', [GameController::class, 'store']);
 Route::match(['get','post'], '/games/{game}/join', [GameController::class, 'join']);
 Route::get('/games/{game}', [GameController::class, 'show']);
+Route::post('/games/{game}/nudge', [GameController::class, 'nudge']);
 
 Route::controller(ChatController::class)->prefix('chat')->group(function () {
     Route::get('/{game?}', 'index');

--- a/tests/Unit/GameNudgeTest.php
+++ b/tests/Unit/GameNudgeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+use App\Models\{Game, GamePlayer, GameNudge, Player, Setting};
+
+class GameNudgeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_nudge_creates_record(): void
+    {
+        Mail::fake();
+        Setting::create(['setting' => 'nudge_flood_control', 'value' => '24']);
+
+        $host = Player::factory()->create();
+        $player = Player::factory()->create();
+        $game = Game::factory()->create(['host_id' => $host->player_id]);
+
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $host->player_id,
+            'order_num' => 1,
+            'color' => 'red',
+            'state' => 'Attacking',
+            'move_date' => now(),
+        ]);
+
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $player->player_id,
+            'order_num' => 2,
+            'color' => 'blue',
+            'state' => 'Attacking',
+            'move_date' => now()->subHours(25),
+        ]);
+
+        $this->withSession(['player_id' => $host->player_id])
+            ->post('/games/' . $game->game_id . '/nudge');
+
+        $this->assertDatabaseHas('game_nudges', [
+            'game_id' => $game->game_id,
+            'player_id' => $player->player_id,
+        ]);
+    }
+
+    public function test_duplicate_nudge_blocked(): void
+    {
+        Mail::fake();
+        Setting::create(['setting' => 'nudge_flood_control', 'value' => '24']);
+
+        $host = Player::factory()->create();
+        $player = Player::factory()->create();
+        $game = Game::factory()->create(['host_id' => $host->player_id]);
+
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $host->player_id,
+            'order_num' => 1,
+            'color' => 'red',
+            'state' => 'Attacking',
+            'move_date' => now(),
+        ]);
+
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $player->player_id,
+            'order_num' => 2,
+            'color' => 'blue',
+            'state' => 'Attacking',
+            'move_date' => now()->subHours(25),
+        ]);
+
+        $this->withSession(['player_id' => $host->player_id])
+            ->post('/games/' . $game->game_id . '/nudge');
+
+        $this->withSession(['player_id' => $host->player_id])
+            ->post('/games/' . $game->game_id . '/nudge');
+
+        $count = GameNudge::where('game_id', $game->game_id)
+            ->where('player_id', $player->player_id)
+            ->count();
+        $this->assertEquals(1, $count);
+    }
+}


### PR DESCRIPTION
## Summary
- add nudge handler in `GameController`
- add POST route for nudging players
- show nudge button in game view
- add tests covering nudge and flood control

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6858693d0e4083339b5ee0ab2536456f