### PR TITLE
30 :: Add navigation links to game view

### DIFF
--- a/resources/views/games/show.blade.php
+++ b/resources/views/games/show.blade.php
@@ -1,6 +1,10 @@
 @extends('layouts.app')
 
 @section('content')
+<ul id="buttons" class="flex gap-4 mb-4">
+    <li><a href="{{ route('games.index') }}" class="text-indigo-600 hover:underline">Main Page</a></li>
+    <li><a href="{{ route('games.show', $game->game_id) }}" class="text-indigo-600 hover:underline">Reload Game Board</a></li>
+</ul>
 <h1 class="text-2xl font-semibold mb-4">{{ $game->name }}</h1>
 <p class="mb-4">State: {{ $game->state }}</p>
 @if(isset($canNudge) && $canNudge)


### PR DESCRIPTION
## Summary
- add navigation links above heading in game view

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68589a0e17308333b8c25a7265f88547