### PR TITLE
31 :: Render full game board

### DIFF
--- a/app/Helpers/BoardHelper.php
+++ b/app/Helpers/BoardHelper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Models\Game;
+use App\Models\GameLand;
+use App\Models\GamePlayer;
+
+class BoardHelper
+{
+    public static function render(Game $game): string
+    {
+        $lands = GameLand::where('game_id', $game->game_id)->get()->keyBy('land_id');
+        $players = GamePlayer::where('game_id', $game->game_id)->get()->keyBy('player_id');
+        $html = '';
+        for ($landId = 1; $landId <= 42; $landId++) {
+            $land = $lands->get($landId);
+            $player = $land ? $players->get($land->player_id) : null;
+            $color = $player ? $player->color : 'gray';
+            $resigned = ($player && $player->state === 'Resigned') ? ' res' : '';
+            $armies = $land ? $land->armies : 0;
+            $html .= '<span class="'.substr($color, 0, 3).$resigned.'" id="sl'.str_pad($landId, 2, '0', STR_PAD_LEFT).'" title="'.str_pad($landId, 2, '0', STR_PAD_LEFT).'">'.$armies.'</span>';
+        }
+        return $html;
+    }
+}

--- a/resources/views/games/show.blade.php
+++ b/resources/views/games/show.blade.php
@@ -13,4 +13,14 @@
     <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Nudge</button>
 </form>
 @endif
+
+<div id="board">
+    <div id="pathmarkers">
+@for($i = 1; $i <= 44; $i++)
+        <div id="pm{{ str_pad($i, 2, '0', STR_PAD_LEFT) }}"></div>
+@endfor
+    </div>
+    <img src="/images/blank.gif" width="800" height="449" usemap="#gamemap" alt="" />
+    {!! App\Helpers\BoardHelper::render($game) !!}
+</div>
 @endsection


### PR DESCRIPTION
## Summary
- add BoardHelper for board HTML
- render board in game view with markers and map

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68589c2f6e588333811701e68460af44