### PR TITLE
FEATURE :: Add tests

### DIFF
--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -24,4 +24,34 @@ class ChatTest extends TestCase
             'game_id' => $game->game_id,
         ]);
     }
+
+    public function test_fetch_returns_messages_for_game(): void
+    {
+        $player = Player::factory()->create();
+        $game = Game::factory()->create(['host_id' => $player->player_id]);
+        \App\Models\Chat::create([
+            'message' => 'first',
+            'from_id' => $player->player_id,
+            'game_id' => $game->game_id,
+            'private' => false,
+        ]);
+        \App\Models\Chat::create([
+            'message' => 'other',
+            'from_id' => $player->player_id,
+            'game_id' => 0,
+            'private' => false,
+        ]);
+        $response = $this->get('/chat/'.$game->game_id.'/messages');
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJsonFragment(['message' => 'first']);
+    }
+
+
+    public function test_post_requires_authentication(): void
+    {
+        $game = Game::factory()->create();
+        $response = $this->post('/chat/'.$game->game_id, ['message' => 'Hi']);
+        $response->assertStatus(401);
+    }
 }

--- a/tests/Unit/GameHashingTest.php
+++ b/tests/Unit/GameHashingTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Game;
+use Tests\TestCase;
+
+class GameHashingTest extends TestCase
+{
+    public function test_hash_password(): void
+    {
+        $password = 'secret';
+        $expected = md5($password.'s41Ty!S7uFF');
+        $this->assertSame($expected, Game::hashPassword($password));
+    }
+}

--- a/tests/Unit/PlayerSettingsRelationTest.php
+++ b/tests/Unit/PlayerSettingsRelationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Player;
+use App\Models\PlayerSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PlayerSettingsRelationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_player_relationship(): void
+    {
+        $player = Player::factory()->create();
+        $settings = PlayerSettings::create(['player_id' => $player->player_id]);
+        $this->assertSame($player->player_id, $settings->player->player_id);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for game password hashing
- ensure PlayerSettings relationship with Player is covered
- expand chat feature tests

## Testing
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68589cfe60e083339dd338afaff18707