### PR TITLE
TEST :: Add board and game tests

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -51,11 +51,7 @@ class Game extends Model
         return $this->hasMany(Chat::class, 'game_id');
     }
 
-    public function get_trade_value(): int
-    {
-        return 0;
-    }
-
+    
     public function draw_players(): string
     {
         $players = $this->players()->with('player')->orderBy('order_num')->get();

--- a/tests/Unit/BoardRenderTest.php
+++ b/tests/Unit/BoardRenderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Helpers\BoardHelper;
+use App\Models\{Game, GameLand, GamePlayer, Player};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BoardRenderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_render_returns_board_html(): void
+    {
+        $game = Game::factory()->create();
+        $p1 = Player::factory()->create();
+        $p2 = Player::factory()->create();
+        GamePlayer::create(['game_id' => $game->game_id, 'player_id' => $p1->player_id, 'order_num' => 1, 'color' => 'red', 'state' => 'Attacking']);
+        GamePlayer::create(['game_id' => $game->game_id, 'player_id' => $p2->player_id, 'order_num' => 2, 'color' => 'blue', 'state' => 'Resigned']);
+        GameLand::create(['game_id' => $game->game_id, 'land_id' => 1, 'player_id' => $p1->player_id, 'armies' => 3]);
+        GameLand::create(['game_id' => $game->game_id, 'land_id' => 2, 'player_id' => $p2->player_id, 'armies' => 2]);
+        $html = BoardHelper::render($game);
+        $this->assertStringContainsString('<span class="red" id="sl01"', $html);
+        $this->assertStringContainsString('>3</span>', $html);
+        $this->assertStringContainsString('<span class="blu res" id="sl02"', $html);
+        $this->assertEquals(42, substr_count($html, '<span'));
+    }
+}

--- a/tests/Unit/GameDrawPlayersTest.php
+++ b/tests/Unit/GameDrawPlayersTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\{Game, GamePlayer, Player};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GameDrawPlayersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_draw_players_outputs_player_list(): void
+    {
+        $host = Player::factory()->create();
+        $player = Player::factory()->create();
+        $game = Game::factory()->create(['host_id' => $host->player_id]);
+        GamePlayer::create(['game_id' => $game->game_id, 'player_id' => $host->player_id, 'order_num' => 1, 'color' => 'red', 'state' => 'Waiting']);
+        GamePlayer::create(['game_id' => $game->game_id, 'player_id' => $player->player_id, 'order_num' => 2, 'color' => 'blue', 'state' => 'Waiting']);
+        session(['player_id' => $player->player_id]);
+        $html = $game->draw_players();
+        $this->assertStringContainsString('id="p_'.$host->player_id.'"', $html);
+        $this->assertStringContainsString('class="red host waiting"', $html);
+        $this->assertStringContainsString('class="blu me waiting"', $html);
+    }
+}

--- a/tests/Unit/GameTradeValueTest.php
+++ b/tests/Unit/GameTradeValueTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\{Game, GameLog};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GameTradeValueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_trade_value_returns_zero_when_no_logs(): void
+    {
+        $game = Game::factory()->create();
+        $this->assertSame(0, $game->get_trade_value());
+    }
+
+    public function test_get_trade_value_returns_latest_value(): void
+    {
+        $game = Game::factory()->create();
+        GameLog::create([
+            'game_id' => $game->game_id,
+            'data' => 'V - Value for Trade - [4]',
+            'create_date' => now()->subMinute(),
+            'microsecond' => 0,
+        ]);
+        GameLog::create([
+            'game_id' => $game->game_id,
+            'data' => 'V - Value for Trade - [7]',
+            'create_date' => now(),
+            'microsecond' => 0,
+        ]);
+        $this->assertSame(7, $game->get_trade_value());
+    }
+}


### PR DESCRIPTION
## Summary
- remove duplicate `get_trade_value` definition
- add tests for trade value logic
- cover player list rendering
- test board rendering helper

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6858a4db75148333a7ae7a59a3196366