### PR TITLE
37 :: Add Game Info modal

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\Game;
+use App\Models\GameLand;
+
+if (!function_exists('game_info')) {
+    function game_info(Game $game): string
+    {
+        $players = $game->players()->with('player')->orderBy('order_num')->get();
+        $info = $players->map(function ($gp) use ($game) {
+            $lands = GameLand::where('game_id', $game->game_id)
+                ->where('player_id', $gp->player_id)
+                ->count();
+            $cards = $gp->cards ? count(array_filter(explode(' ', $gp->cards))) : 0;
+            return [
+                'order' => $gp->order_num,
+                'username' => $gp->player->username ?? '',
+                'state' => $gp->state,
+                'armies' => $gp->armies,
+                'land' => $lands,
+                'cards' => $cards,
+            ];
+        });
+
+        return view('games.partials.game_info', [
+            'game' => $game,
+            'players' => $info,
+        ])->render();
+    }
+}
+

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,9 @@
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
-            "Database\\Seeders\\": "database/seeders/"
-        }
+        "Database\\Seeders\\": "database/seeders/"
+        },
+        "files": ["app/helpers.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/resources/views/games/partials/game_info.blade.php
+++ b/resources/views/games/partials/game_info.blade.php
@@ -1,0 +1,43 @@
+<div id="game_info">
+    <h2 class="text-xl font-semibold mb-2">Game Info</h2>
+    <table class="min-w-full mb-4">
+        <thead>
+            <tr>
+                <th>Order</th>
+                <th>Player</th>
+                <th>State</th>
+                <th>Armies</th>
+                <th>Land</th>
+                <th>Cards</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($players as $p)
+            <tr class="border-t">
+                <td>{{ $p['order'] }}</td>
+                <td>{{ $p['username'] }}</td>
+                <td>{{ $p['state'] }}</td>
+                <td>{{ $p['armies'] }}</td>
+                <td>{{ $p['land'] }}</td>
+                <td>{{ $p['cards'] }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+    <table class="min-w-full">
+        <tbody>
+            <tr>
+                <th class="text-left pr-2">Game Type</th>
+                <td>{{ $game->game_type }}</td>
+            </tr>
+            <tr>
+                <th class="text-left pr-2">Paused</th>
+                <td>{{ $game->paused ? 'Yes' : 'No' }}</td>
+            </tr>
+            <tr>
+                <th class="text-left pr-2">Next Bonus</th>
+                <td>{{ $game->next_bonus }}</td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/resources/views/games/show.blade.php
+++ b/resources/views/games/show.blade.php
@@ -5,7 +5,9 @@
     <li><a href="{{ route('games.index') }}" class="text-indigo-600 hover:underline">Main Page</a></li>
     <li><a href="{{ route('games.show', $game->game_id) }}" class="text-indigo-600 hover:underline">Reload Game Board</a></li>
 </ul>
-<h1 class="text-2xl font-semibold mb-4">{{ $game->name }}</h1>
+<h1 class="text-2xl font-semibold mb-4">{{ $game->name }}
+    <a href="#" id="game-info-link" class="text-sm ml-2 text-indigo-600 hover:underline">Game Info</a>
+</h1>
 <p class="mb-4">State: {{ $game->state }}</p>
 @if(isset($canNudge) && $canNudge)
 <form method="post" action="/games/{{ $game->game_id }}/nudge" class="mb-4">
@@ -49,6 +51,7 @@
 <div id="history" class="mt-4">
     <a href="{{ route('history.index', $game) }}" class="text-indigo-600 hover:underline ajax-modal">Click for History</a>
 </div>
+{!! game_info($game) !!}
 <div id="ajax-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
     <div class="bg-white p-4 rounded w-11/12 max-w-2xl max-h-[80vh] overflow-y-auto">
         <button id="ajax-modal-close" type="button" class="ml-auto mb-2 text-gray-500">Close</button>
@@ -102,6 +105,13 @@ document.querySelectorAll('.ajax-modal').forEach(link => {
                 modal.classList.remove('hidden');
             });
     });
+});
+const gameInfo = document.getElementById('game_info');
+gameInfo.classList.add('hidden');
+document.getElementById('game-info-link').addEventListener('click', e => {
+    e.preventDefault();
+    modalContent.innerHTML = gameInfo.innerHTML;
+    modal.classList.remove('hidden');
 });
 document.getElementById('ajax-modal-close').addEventListener('click', closeModal);
 modal.addEventListener('click', e => {


### PR DESCRIPTION
## Summary
- add global game_info helper and autoload file
- render new game info partial
- show Game Info modal on game page with JS trigger

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6858ae9f69a88333809662ec4ada9abf