### PR TITLE
39 :: Apply Tailwind styling to game page

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -54,7 +54,7 @@ class Game extends Model
     public function draw_players(): string
     {
         $players = $this->players()->with('player')->orderBy('order_num')->get();
-        $html = '<div id="players"><ul>';
+        $html = '<div id="players" class="absolute bottom-0 left-0 z-10 w-36 bg-black/80 text-white border-2 border-gray-300 border-b-0 overflow-hidden"><ul class="ml-6 space-y-1">';
         foreach ($players as $gp) {
             $class = substr($gp->color, 0, 3);
             if ($gp->player_id == session('player_id')) {
@@ -66,7 +66,7 @@ class Game extends Model
             $class .= ' '.strtolower($gp->state);
             $numCards = $gp->cards ? count(array_filter(explode(' ', $gp->cards))) : 0;
             $username = $gp->player->username ?? '';
-            $html .= '<li id="p_'.$gp->player_id.'" class="'.$class.'" title="'.$gp->state.'"><span class="cards">'.$numCards.'</span>'.$username.'</li>';
+            $html .= '<li id="p_'.$gp->player_id.'" class="'.$class.' text-left border border-gray-600 px-1 text-xs font-bold list-none" title="'.$gp->state.'"><span class="cards">'.$numCards.'</span>'.$username.'</li>';
         }
         return $html.'</ul></div>';
     }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -9,3 +9,11 @@
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', 'Noto Color Emoji';
 }
+
+@layer utilities {
+    .board-background {
+        background-image: url('/legacy/images/board.jpg');
+        background-repeat: no-repeat;
+        background-position: center;
+    }
+}

--- a/resources/views/games/show.blade.php
+++ b/resources/views/games/show.blade.php
@@ -16,7 +16,8 @@
 </form>
 @endif
 
-<div id="board">
+<div class="flex flex-col lg:flex-row gap-4">
+<div id="board" class="relative board-background border border-gray-300 w-full max-w-[800px] h-[449px] mx-auto lg:mx-0">
     <div id="pathmarkers">
 @for($i = 1; $i <= 44; $i++)
         <div id="pm{{ str_pad($i, 2, '0', STR_PAD_LEFT) }}"></div>
@@ -34,7 +35,7 @@
         @endif
     </div>
 </div>
-<div id="controls">
+<div id="controls" class="lg:ml-4 lg:w-64 border border-gray-300 p-2 bg-white mt-4 lg:mt-0">
     {!! $game->draw_action() !!}
     <hr />
     <div id="chat-panel" class="mt-4">
@@ -47,6 +48,7 @@
             <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Send</button>
         </form>
     </div>
+</div>
 </div>
 <div id="history" class="mt-4">
     <a href="{{ route('history.index', $game) }}" class="text-indigo-600 hover:underline ajax-modal">Click for History</a>

--- a/tests/Unit/GameDrawPlayersTest.php
+++ b/tests/Unit/GameDrawPlayersTest.php
@@ -20,7 +20,7 @@ class GameDrawPlayersTest extends TestCase
         session(['player_id' => $player->player_id]);
         $html = $game->draw_players();
         $this->assertStringContainsString('id="p_'.$host->player_id.'"', $html);
-        $this->assertStringContainsString('class="red host waiting"', $html);
-        $this->assertStringContainsString('class="blu me waiting"', $html);
+        $this->assertStringContainsString('class="red host waiting', $html);
+        $this->assertStringContainsString('class="blu me waiting', $html);
     }
 }


### PR DESCRIPTION
## Summary
- style game page layout with Tailwind
- enhance player list markup
- add board background utility
- update failing test

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6858c16acadc833388d971e5fb7b329e