### PR TITLE
FEATURE :: Conquer limit progress UI

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -34,6 +34,7 @@ class Game extends Model
     protected $casts = [
         'allow_kibitz' => 'boolean',
         'paused' => 'boolean',
+        'extra_info' => 'array',
     ];
 
     public function host()
@@ -69,6 +70,11 @@ class Game extends Model
             $html .= '<li id="p_'.$gp->player_id.'" class="'.$class.' text-left border border-gray-600 px-1 text-xs font-bold list-none" title="'.$gp->state.'"><span class="cards">'.$numCards.'</span>'.$username.'</li>';
         }
         return $html.'</ul></div>';
+    }
+
+    public function getConquerLimit(): ?int
+    {
+        return $this->extra_info['conquer_limit'] ?? null;
     }
 
     public static function hashPassword(string $password): string

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -33,6 +33,7 @@ class GamePlayer extends Model
 
     protected $casts = [
         'move_date' => 'datetime',
+        'extra_info' => 'array',
     ];
 
     public function game()
@@ -43,5 +44,10 @@ class GamePlayer extends Model
     public function player()
     {
         return $this->belongsTo(Player::class, 'player_id');
+    }
+
+    public function getConquered(): int
+    {
+        return $this->extra_info['conquered'] ?? 0;
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -13,12 +13,14 @@ if (!function_exists('game_info')) {
                 ->count();
             $cards = $gp->cards ? count(array_filter(explode(' ', $gp->cards))) : 0;
             return [
+                'player_id' => $gp->player_id,
                 'order' => $gp->order_num,
                 'username' => $gp->player->username ?? '',
                 'state' => $gp->state,
                 'armies' => $gp->armies,
                 'land' => $lands,
                 'cards' => $cards,
+                'conquered' => $gp->extra_info['conquered'] ?? 0,
             ];
         });
 

--- a/resources/views/games/partials/game_info.blade.php
+++ b/resources/views/games/partials/game_info.blade.php
@@ -40,4 +40,29 @@
             </tr>
         </tbody>
     </table>
+    @if($limit = $game->getConquerLimit())
+    <h3 class="text-lg font-semibold mt-4">Conquer Limit Progress</h3>
+    <table class="min-w-full mb-4">
+        <thead>
+            <tr>
+                <th>Player</th>
+                <th>Progress</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($players as $p)
+            @php $width = $limit ? min(100, ($p['conquered'] / $limit) * 100) : 0; @endphp
+            <tr class="border-t">
+                <td>{{ $p['username'] }}</td>
+                <td>
+                    <div class="w-full bg-gray-200 h-2" title="{{ $p['conquered'] }} / {{ $limit }}">
+                        <div class="bg-green-500 h-2" style="width: {{ $width }}%"></div>
+                    </div>
+                    <span class="sr-only">{{ $p['conquered'] }} / {{ $limit }}</span>
+                </td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+    @endif
 </div>

--- a/tests/Feature/ConquerLimitProgressTest.php
+++ b/tests/Feature/ConquerLimitProgressTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Game;
+use App\Models\GamePlayer;
+use App\Models\Player;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConquerLimitProgressTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_progress_indicator_displays()
+    {
+        $host = Player::factory()->create();
+        $extra = ['conquer_limit' => 3];
+        $game = Game::factory()->create([
+            'host_id' => $host->player_id,
+            'extra_info' => $extra,
+        ]);
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $host->player_id,
+            'order_num' => 1,
+            'color' => 'red',
+            'state' => 'Waiting',
+            'extra_info' => ['conquered' => 1],
+        ]);
+        $p2 = Player::factory()->create();
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $p2->player_id,
+            'order_num' => 2,
+            'color' => 'blue',
+            'state' => 'Waiting',
+            'extra_info' => ['conquered' => 2],
+        ]);
+
+        $response = $this->get('/games/' . $game->game_id);
+        $response->assertStatus(200);
+        $response->assertSee('1 / 3', false);
+        $response->assertSee('2 / 3', false);
+    }
+}


### PR DESCRIPTION
## Summary
- add array cast for `extra_info` fields
- provide `getConquerLimit()` and `getConquered()` helpers
- expose conquer status via `game_info` helper and partial
- render progress indicator on the game info page
- cover with feature test

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6858ddba95808333aab74d9f1b4c307f