### PR TITLE
53 :: Refactor trade and conquer tables

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -22,9 +22,16 @@ if (!function_exists('game_info')) {
             ];
         });
 
+        $extra = $game->extra_info ? json_decode($game->extra_info, true) : [];
+        $tradeValues = $extra['trade_values'] ?? [];
+        $tradeHtml = $tradeValues ? trade_table($tradeValues, $extra['trade_count'] ?? 0) : '';
+        $conquerHtml = isset($extra['conquer_type']) ? conquer_limit_table($extra) : '';
+
         return view('games.partials.game_info', [
             'game' => $game,
             'players' => $info,
+            'tradeHtml' => $tradeHtml,
+            'conquerHtml' => $conquerHtml,
         ])->render();
     }
 }
@@ -36,3 +43,128 @@ if (!function_exists('game_map')) {
     }
 }
 
+
+if (!function_exists('trade_table')) {
+    function trade_table(array $tradeValues, int $tradeCount = 0): string
+    {
+        $tradeCount++;
+        $rows = [];
+        $prev = 0;
+        foreach ($tradeValues as $trade => $value) {
+            $idx = $trade + 1;
+            if (is_string($value) && $value !== '' && $value[0] === '-') {
+                $next = $prev;
+                while (0 < $next) {
+                    $next += (int) $value;
+                    if (0 >= $next) {
+                        $idx--;
+                        break;
+                    }
+                    $rows[] = ['idx' => $idx, 'value' => $next];
+                    $idx++;
+                }
+                while ($idx <= $tradeCount) {
+                    $rows[] = ['idx' => $idx, 'value' => 0];
+                    $idx++;
+                }
+                $rows[] = ['idx' => $idx, 'value' => 0];
+                $idx++;
+                $rows[] = ['idx' => $idx, 'value' => 0];
+                $idx++;
+                $rows[] = ['idx' => $idx, 'value' => '...'];
+            } elseif (is_string($value) && $value[0] === '+') {
+                $next = $prev;
+                while ($idx <= $tradeCount) {
+                    $next += (int) $value;
+                    $rows[] = ['idx' => $idx, 'value' => $next];
+                    $idx++;
+                }
+                for ($i = 1; $i <= 3; $i++) {
+                    $next += (int) $value;
+                    $rows[] = ['idx' => $idx, 'value' => $next];
+                    $idx++;
+                }
+                $rows[] = ['idx' => $idx, 'value' => '(' . $value . ')'];
+            } else {
+                $rows[] = ['idx' => $idx, 'value' => $value];
+                $prev = $value;
+            }
+        }
+        $last = end($tradeValues);
+        if (!is_string($last) || !in_array($last[0], ['+', '-'])) {
+            $idx = count($tradeValues) + 1;
+            $value = $last;
+            while ($idx <= $tradeCount) {
+                $rows[] = ['idx' => $idx, 'value' => $value];
+                $idx++;
+            }
+            $rows[] = ['idx' => $idx, 'value' => $value];
+            $idx++;
+            $rows[] = ['idx' => $idx, 'value' => $value];
+            $idx++;
+            $rows[] = ['idx' => $idx, 'value' => '...'];
+        }
+        foreach ($rows as &$r) {
+            $r['highlight'] = ($r['idx'] === $tradeCount);
+        }
+        return view('components.trade-table', ['rows' => $rows])->render();
+    }
+}
+
+if (!function_exists('conquer_limit_table')) {
+    function conquer_limit_table(array $extra): string
+    {
+        if (($extra['conquer_type'] ?? 'none') === 'none') {
+            return '';
+        }
+        $type = $extra['conquer_type'];
+        $skip = (int)($extra['conquer_skip'] ?? 0);
+        $startAt = (int)($extra['conquer_start_at'] ?? 0);
+        $conquestsPer = (int)($extra['conquer_conquests_per'] ?? 1);
+        $perNumber = (int)($extra['conquer_per_number'] ?? 0);
+        if (!$perNumber) {
+            $perNumber = match ($type) {
+                'trade_value' => 10,
+                'trade_count' => 2,
+                'rounds' => 1,
+                'turns' => 1,
+                'land' => 3,
+                'continents' => 1,
+                'armies' => 10,
+                default => 1,
+            };
+        }
+        $minimum = (int)($extra['conquer_minimum'] ?? 1);
+        if ($minimum < 1) {
+            $minimum = 1;
+        }
+        $maximum = (int)($extra['conquer_maximum'] ?? 42);
+        $startCount = in_array($type, ['trade_value', 'trade_count', 'continents']) ? 0 : 1;
+        $conquests = [];
+        $repeats = 0;
+        $prev = 0;
+        for ($n = 0; $n <= 200; $n++) {
+            $limit = max((((((int) floor(($n - $startCount) / $perNumber)) + 1) - $skip) * $conquestsPer), 0) + $startAt;
+            $limit = max($minimum, min($limit, $maximum));
+            if ($limit !== $prev) {
+                $prev = $limit;
+            } elseif ($limit === $maximum) {
+                $repeats++;
+            }
+            $conquests[$n] = $limit;
+            if ($repeats >= 3) {
+                $conquests['...'] = $limit;
+                break;
+            }
+        }
+        if (!in_array($type, ['trade_value', 'trade_count', 'continents'])) {
+            unset($conquests[0]);
+        }
+        $equation = "max( ( ( ( floor( (x - {$startCount}) / <span class=\"per_number\">{$perNumber}</span> ) + 1 ) - <span class=\"skip\">{$skip}</span> ) * <span class=\"conquests_per\">{$conquestsPer}</span> ) , 0 ) + <span class=\"start_at\">{$startAt}</span>";
+        return view('components.conquer-limit-table', [
+            'type' => $type,
+            'limits' => $conquests,
+            'equation' => $equation,
+        ])->render();
+    }
+}

--- a/resources/views/components/conquer-limit-table.blade.php
+++ b/resources/views/components/conquer-limit-table.blade.php
@@ -1,0 +1,17 @@
+<table class="datatable conquer_limits">
+    <caption>{!! $equation !!}</caption>
+    <thead>
+        <tr>
+            <th id="conquer_type_header">{{ ucwords(str_replace('_',' ', $type)) }}</th>
+            <th>Conquer Limit</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($limits as $count => $value)
+        <tr class="{{ $loop->iteration % 2 === 0 ? 'alt' : '' }}">
+            <td>{{ $count }}</td>
+            <td>{{ $value }}</td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>

--- a/resources/views/components/trade-table.blade.php
+++ b/resources/views/components/trade-table.blade.php
@@ -1,0 +1,16 @@
+<table class="datatable custom_trades">
+    <thead>
+        <tr>
+            <th>Trade #</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($rows as $row)
+        <tr class="{{ $loop->iteration % 2 === 0 ? 'alt' : '' }}{{ $row['highlight'] ? ' highlight' : '' }}">
+            <td>{{ $row['idx'] }}</td>
+            <td>{{ $row['value'] }}</td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>

--- a/resources/views/games/partials/game_info.blade.php
+++ b/resources/views/games/partials/game_info.blade.php
@@ -40,4 +40,10 @@
             </tr>
         </tbody>
     </table>
+    @if(!empty($tradeHtml))
+        {!! $tradeHtml !!}
+    @endif
+    @if(!empty($conquerHtml))
+        {!! $conquerHtml !!}
+    @endif
 </div>

--- a/tests/Feature/GameInfoTablesTest.php
+++ b/tests/Feature/GameInfoTablesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{Game, Player, GamePlayer};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GameInfoTablesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_game_info_displays_tables(): void
+    {
+        $player = Player::factory()->create();
+        $game = Game::factory()->create([
+            'host_id' => $player->player_id,
+            'extra_info' => json_encode([
+                'trade_values' => [4,6,8],
+                'trade_count' => 0,
+                'conquer_type' => 'trade_value',
+                'conquer_conquests_per' => 1,
+                'conquer_per_number' => 10,
+                'conquer_skip' => 0,
+                'conquer_start_at' => 0,
+                'conquer_minimum' => 1,
+                'conquer_maximum' => 5,
+            ]),
+        ]);
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $player->player_id,
+            'order_num' => 1,
+            'color' => 'red',
+            'state' => 'Waiting',
+        ]);
+
+        $html = game_info($game);
+        $this->assertStringContainsString('custom_trades', $html);
+        $this->assertStringContainsString('conquer_limits', $html);
+    }
+}

--- a/tests/Unit/ConquerLimitTableTest.php
+++ b/tests/Unit/ConquerLimitTableTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class ConquerLimitTableTest extends TestCase
+{
+    public function test_conquer_limit_table_builds_values(): void
+    {
+        $data = [
+            'conquer_type' => 'trade_value',
+            'conquer_conquests_per' => 1,
+            'conquer_per_number' => 10,
+            'conquer_skip' => 0,
+            'conquer_start_at' => 0,
+            'conquer_minimum' => 1,
+            'conquer_maximum' => 5,
+        ];
+        $html = conquer_limit_table($data);
+        $this->assertStringContainsString('Conquer Limit', $html);
+        $this->assertStringContainsString('<td>1</td>', $html);
+    }
+}

--- a/tests/Unit/TradeTableTest.php
+++ b/tests/Unit/TradeTableTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class TradeTableTest extends TestCase
+{
+    public function test_trade_table_generates_rows(): void
+    {
+        $html = trade_table([4,6,8]);
+        $this->assertStringContainsString('>1</td>', $html);
+        $this->assertStringContainsString('>8</td>', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- add `trade_table` and `conquer_limit_table` helpers
- render new components in game info view
- create blade views for trade and conquer tables
- test helpers and rendering

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_685a346842048333bf00c4ba47903890