### PR TITLE
54 :: placement nudge & card fog

### DIFF
--- a/app/Http/Controllers/GameController.php
+++ b/app/Http/Controllers/GameController.php
@@ -45,6 +45,7 @@ class GameController extends Controller
             'warmonger' => 'boolean',
             'fog_of_war_armies' => 'required|in:all,adjacent,none',
             'fog_of_war_colors' => 'required|in:all,adjacent,none',
+            'fog_of_war_cards' => 'required|in:all,self',
             'nuke' => 'boolean',
             'turncoat' => 'boolean',
             'place_initial_armies' => 'boolean',
@@ -59,6 +60,7 @@ class GameController extends Controller
             'warmonger' => (bool) ($data['warmonger'] ?? false),
             'fog_of_war_armies' => $data['fog_of_war_armies'],
             'fog_of_war_colors' => $data['fog_of_war_colors'],
+            'fog_of_war_cards' => $data['fog_of_war_cards'],
             'nuke' => (bool) ($data['nuke'] ?? false),
             'turncoat' => (bool) ($data['turncoat'] ?? false),
             'place_initial_armies' => (bool) ($data['place_initial_armies'] ?? false),
@@ -147,8 +149,12 @@ class GameController extends Controller
 
     protected function nudgablePlayers(Game $game, int $hours): array
     {
+        $exclude = ['Resigned', 'Dead'];
+        if ($game->state !== 'Placing') {
+            $exclude[] = 'Waiting';
+        }
         $players = GamePlayer::where('game_id', $game->game_id)
-            ->whereNotIn('state', ['Waiting', 'Resigned', 'Dead'])
+            ->whereNotIn('state', $exclude)
             ->get();
         $ids = [];
         foreach ($players as $gp) {

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -55,6 +55,8 @@ class Game extends Model
     {
         $players = $this->players()->with('player')->orderBy('order_num')->get();
         $html = '<div id="players" class="absolute bottom-0 left-0 z-10 w-36 bg-black/80 text-white border-2 border-gray-300 border-b-0 overflow-hidden"><ul class="ml-6 space-y-1">';
+        $extra = $this->extra_info ? json_decode($this->extra_info, true) : [];
+        $fowCards = $extra['fog_of_war_cards'] ?? 'all';
         foreach ($players as $gp) {
             $class = substr($gp->color, 0, 3);
             if ($gp->player_id == session('player_id')) {
@@ -65,8 +67,9 @@ class Game extends Model
             }
             $class .= ' '.strtolower($gp->state);
             $numCards = $gp->cards ? count(array_filter(explode(' ', $gp->cards))) : 0;
+            $displayCards = ($fowCards === 'all' || $gp->player_id == session('player_id')) ? $numCards : '?';
             $username = $gp->player->username ?? '';
-            $html .= '<li id="p_'.$gp->player_id.'" class="'.$class.' text-left border border-gray-600 px-1 text-xs font-bold list-none" title="'.$gp->state.'"><span class="cards">'.$numCards.'</span>'.$username.'</li>';
+            $html .= '<li id="p_'.$gp->player_id.'" class="'.$class.' text-left border border-gray-600 px-1 text-xs font-bold list-none" title="'.$gp->state.'"><span class="cards">'.$displayCards.'</span>'.$username.'</li>';
         }
         return $html.'</ul></div>';
     }

--- a/resources/views/games/create.blade.php
+++ b/resources/views/games/create.blade.php
@@ -51,6 +51,13 @@
         </div>
     </div>
     <div>
+        <label class="block mb-1">Fog of War Cards</label>
+        <div class="flex gap-2">
+            <label class="flex items-center gap-1"><input type="radio" class="rounded" name="fog_of_war_cards" value="all" @checked(old('fog_of_war_cards','all')=='all')>All</label>
+            <label class="flex items-center gap-1"><input type="radio" class="rounded" name="fog_of_war_cards" value="self" @checked(old('fog_of_war_cards')=='self')>Self Only</label>
+        </div>
+    </div>
+    <div>
         <label class="flex items-center gap-2"><input type="checkbox" class="rounded" name="nuke" value="1" @checked(old('nuke'))>Nuclear War</label>
     </div>
     <div>

--- a/tests/Feature/FogOfWarCardsTest.php
+++ b/tests/Feature/FogOfWarCardsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{Game, GamePlayer, Player};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FogOfWarCardsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_card_count_visible_without_fog(): void
+    {
+        $host = Player::factory()->create();
+        $player = Player::factory()->create();
+        $extra = [
+            'fog_of_war_armies' => 'all',
+            'fog_of_war_colors' => 'all',
+            'fog_of_war_cards' => 'all'
+        ];
+        $game = Game::factory()->create([
+            'host_id' => $host->player_id,
+            'extra_info' => json_encode($extra)
+        ]);
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $host->player_id,
+            'order_num' => 1,
+            'color' => 'red',
+            'state' => 'Attacking',
+            'cards' => 'i1 i2'
+        ]);
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $player->player_id,
+            'order_num' => 2,
+            'color' => 'blue',
+            'state' => 'Attacking',
+            'cards' => 'i3 i4'
+        ]);
+        $response = $this->withSession(['player_id' => $host->player_id])
+            ->get('/games/' . $game->game_id);
+        $response->assertSee('<span class="cards">2</span>', false);
+    }
+
+    public function test_card_count_hidden_with_fog(): void
+    {
+        $host = Player::factory()->create();
+        $player = Player::factory()->create();
+        $extra = [
+            'fog_of_war_armies' => 'all',
+            'fog_of_war_colors' => 'all',
+            'fog_of_war_cards' => 'self'
+        ];
+        $game = Game::factory()->create([
+            'host_id' => $host->player_id,
+            'extra_info' => json_encode($extra)
+        ]);
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $host->player_id,
+            'order_num' => 1,
+            'color' => 'red',
+            'state' => 'Attacking',
+            'cards' => 'i1 i2'
+        ]);
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $player->player_id,
+            'order_num' => 2,
+            'color' => 'blue',
+            'state' => 'Attacking',
+            'cards' => 'i3 i4'
+        ]);
+        $response = $this->withSession(['player_id' => $host->player_id])
+            ->get('/games/' . $game->game_id);
+        $response->assertSee('<span class="cards">?</span>', false);
+    }
+}

--- a/tests/Feature/GameRoutesTest.php
+++ b/tests/Feature/GameRoutesTest.php
@@ -44,6 +44,7 @@ class GameRoutesTest extends TestCase
             'fortify' => true,
             'fog_of_war_armies' => 'all',
             'fog_of_war_colors' => 'all',
+            'fog_of_war_cards' => 'all',
             'initial_army_limit' => 0,
         ]);
         $game = Game::first();

--- a/tests/Unit/GameNudgeTest.php
+++ b/tests/Unit/GameNudgeTest.php
@@ -85,4 +85,40 @@ class GameNudgeTest extends TestCase
             ->count();
         $this->assertEquals(1, $count);
     }
+
+    public function test_waiting_player_nudged_during_placement(): void
+    {
+        Mail::fake();
+        Setting::create(['setting' => 'nudge_flood_control', 'value' => '24']);
+
+        $host = Player::factory()->create();
+        $player = Player::factory()->create();
+        $game = Game::factory()->create(['host_id' => $host->player_id, 'state' => 'Placing']);
+
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $host->player_id,
+            'order_num' => 1,
+            'color' => 'red',
+            'state' => 'Placing',
+            'move_date' => now(),
+        ]);
+
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $player->player_id,
+            'order_num' => 2,
+            'color' => 'blue',
+            'state' => 'Waiting',
+            'move_date' => now()->subHours(25),
+        ]);
+
+        $this->withSession(['player_id' => $host->player_id])
+            ->post('/games/' . $game->game_id . '/nudge');
+
+        $this->assertDatabaseHas('game_nudges', [
+            'game_id' => $game->game_id,
+            'player_id' => $player->player_id,
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary
- allow nudging players who are still Waiting during placement phase
- add fog of war cards option for games
- hide other players' card counts when fog is enabled
- show new setting on game create form
- test fog card visibility and placement nudging

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_685b754dbc08833386e72a814a3baef8