### PR TITLE
FEATURE :: show conquer progress

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -16,4 +16,7 @@
         background-repeat: no-repeat;
         background-position: center;
     }
+    .highlight {
+        @apply bg-yellow-200;
+    }
 }

--- a/resources/views/components/conquer-limit-table.blade.php
+++ b/resources/views/components/conquer-limit-table.blade.php
@@ -8,7 +8,7 @@
     </thead>
     <tbody>
     @foreach($limits as $count => $value)
-        <tr class="{{ $loop->iteration % 2 === 0 ? 'alt' : '' }}">
+        <tr class="{{ $loop->iteration % 2 === 0 ? 'alt' : '' }}{{ $highlight == $value ? ' highlight' : '' }}">
             <td>{{ $count }}</td>
             <td>{{ $value }}</td>
         </tr>

--- a/resources/views/components/conquer-progress.blade.php
+++ b/resources/views/components/conquer-progress.blade.php
@@ -1,0 +1,7 @@
+<div class="conquer-progress my-4" aria-label="Conquer progress">
+    <div class="mb-1 text-sm">{{ $conquered }} / {{ $limit }} conquered</div>
+    <div class="w-full bg-gray-200 h-2 rounded">
+        <div class="bg-indigo-600 h-2 rounded" style="width: {{ $percent }}%"></div>
+    </div>
+</div>
+

--- a/resources/views/games/partials/game_info.blade.php
+++ b/resources/views/games/partials/game_info.blade.php
@@ -46,4 +46,7 @@
     @if(!empty($conquerHtml))
         {!! $conquerHtml !!}
     @endif
+    @if(!empty($conquerProgress))
+        {!! $conquerProgress !!}
+    @endif
 </div>

--- a/tests/Feature/GameConquerProgressTest.php
+++ b/tests/Feature/GameConquerProgressTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{Game, Player, GamePlayer};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GameConquerProgressTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_game_info_displays_conquer_progress(): void
+    {
+        $player = Player::factory()->create();
+        $game = Game::factory()->create([
+            'host_id' => $player->player_id,
+            'extra_info' => json_encode([
+                'trade_values' => [4,6,8],
+                'trade_count' => 2,
+                'conquer_type' => 'trade_count',
+                'conquer_conquests_per' => 1,
+                'conquer_per_number' => 2,
+                'conquer_skip' => 0,
+                'conquer_start_at' => 0,
+                'conquer_minimum' => 1,
+                'conquer_maximum' => 5,
+            ]),
+        ]);
+        GamePlayer::create([
+            'game_id' => $game->game_id,
+            'player_id' => $player->player_id,
+            'order_num' => 1,
+            'color' => 'red',
+            'state' => 'Waiting',
+            'extra_info' => json_encode(['conquered' => 1, 'round' => 1, 'turn' => 1]),
+        ]);
+
+        $this->withSession(['player_id' => $player->player_id]);
+        $html = game_info($game);
+
+        $this->assertStringContainsString('conquer-progress', $html);
+        $this->assertStringContainsString('1 / 2', $html);
+        $this->assertStringContainsString('highlight', $html);
+    }
+}

--- a/tests/Unit/ConquerLimitTableTest.php
+++ b/tests/Unit/ConquerLimitTableTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Unit;
 
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ConquerLimitTableTest extends TestCase
 {
+    use RefreshDatabase;
     public function test_conquer_limit_table_builds_values(): void
     {
         $data = [
@@ -20,5 +22,28 @@ class ConquerLimitTableTest extends TestCase
         $html = conquer_limit_table($data);
         $this->assertStringContainsString('Conquer Limit', $html);
         $this->assertStringContainsString('<td>1</td>', $html);
+    }
+
+    public function test_calculate_conquer_limit_returns_value(): void
+    {
+        $game = \App\Models\Game::factory()->create([
+            'extra_info' => json_encode([
+                'conquer_type' => 'trade_count',
+                'conquer_conquests_per' => 1,
+                'conquer_per_number' => 2,
+                'conquer_skip' => 0,
+                'conquer_start_at' => 0,
+                'conquer_minimum' => 1,
+                'conquer_maximum' => 5,
+                'trade_count' => 2,
+            ]),
+        ]);
+        $player = \App\Models\GamePlayer::factory()->create([
+            'game_id' => $game->game_id,
+            'player_id' => 1,
+            'extra_info' => json_encode(['conquered' => 1, 'round' => 1, 'turn' => 1]),
+        ]);
+        $limit = calculate_conquer_limit($game, $player);
+        $this->assertSame(2, $limit);
     }
 }


### PR DESCRIPTION
## Summary
- compute conquer limit for logged in player
- highlight current limit in conquer table
- display progress indicator
- add unit and feature tests

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685b78393dc083339fe671dae6fc3f61